### PR TITLE
Drive event-loop wakeups from store deadline

### DIFF
--- a/src/core/event_handler.rs
+++ b/src/core/event_handler.rs
@@ -46,7 +46,7 @@ impl EventHandler {
         clock: Arc<dyn Clock>,
     ) {
         loop {
-            let now_ms = Utc::now().timestamp_millis() as u64;
+            let now_ms = clock.now();
             let next_deadline = store.next_deadline().map(|deadline_ms| {
                 Instant::now() + Duration::from_millis(deadline_ms.saturating_sub(now_ms))
             });

--- a/src/core/event_handler.rs
+++ b/src/core/event_handler.rs
@@ -36,8 +36,10 @@ impl EventHandler {
         logger: Arc<dyn Logger>,
     ) {
         loop {
-            // TODO get deadline from store
-            let next_deadline = Some(Instant::now() + Duration::from_millis(2));
+            let now_ms = Utc::now().timestamp_millis() as u64;
+            let next_deadline = store.next_deadline().map(|deadline_ms| {
+                Instant::now() + Duration::from_millis(deadline_ms.saturating_sub(now_ms))
+            });
 
             tokio::select! {
                 // New event arrived

--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -53,6 +53,16 @@ impl Store {
         }
     }
 
+    pub fn next_deadline(&self) -> Option<TimeT> {
+        if !self.overdue.is_empty() {
+            return Some(self.tick);
+        }
+        if self.lookup.is_empty() {
+            return None;
+        }
+        Some(self.tick + self.short_wheel.resolution)
+    }
+
     pub fn pop(&mut self, now: TimeT) -> Bucket {
         // Pop overdue timers regardless of whether we're processing new ticks.
         let mut timers = std::mem::take(&mut self.overdue);
@@ -269,6 +279,40 @@ mod tests {
         // Advance by 500ms + one tick, all timers pop.
         clock.advance(500 + TIMER_GRANULARITY_MS);
         assert_eq!(3, store.pop(clock.now()).len());
+    }
+
+    #[test]
+    fn next_deadline_empty_store() {
+        let (_clock, store) = setup();
+        assert_eq!(None, store.next_deadline());
+    }
+
+    #[test]
+    fn next_deadline_with_future_timer() {
+        let (clock, mut store) = setup();
+        store.insert(Timer::new(TimerId::new(), clock.now(), 1000));
+        assert_eq!(Some(TIMER_GRANULARITY_MS), store.next_deadline());
+    }
+
+    #[test]
+    fn next_deadline_with_overdue_timer() {
+        let (mut clock, mut store) = setup();
+        clock.advance(500);
+        // Advance the store's internal tick so the next insert lands in overdue.
+        store.pop(clock.now());
+        store.insert(Timer::new(TimerId::new(), 0, 100));
+        assert_eq!(Some(store.tick), store.next_deadline());
+    }
+
+    #[test]
+    fn next_deadline_after_pop_drains_wheels() {
+        let (mut clock, mut store) = setup();
+        store.insert(Timer::new(TimerId::new(), clock.now(), 100));
+
+        clock.advance(100 + TIMER_GRANULARITY_MS);
+        assert_eq!(1, store.pop(clock.now()).len());
+
+        assert_eq!(None, store.next_deadline());
     }
 
     #[test]

--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn next_deadline_with_future_timer() {
         let (clock, mut store) = setup();
-        store.insert(Timer::new(TimerId::new(), clock.now(), 1000));
+        store.insert(Timer::new(TimerId::new(), clock.now(), 1000, None));
         assert_eq!(Some(TIMER_GRANULARITY_MS), store.next_deadline());
     }
 
@@ -301,14 +301,14 @@ mod tests {
         clock.advance(500);
         // Advance the store's internal tick so the next insert lands in overdue.
         store.pop(clock.now());
-        store.insert(Timer::new(TimerId::new(), 0, 100));
+        store.insert(Timer::new(TimerId::new(), 0, 100, None));
         assert_eq!(Some(store.tick), store.next_deadline());
     }
 
     #[test]
     fn next_deadline_after_pop_drains_wheels() {
         let (mut clock, mut store) = setup();
-        store.insert(Timer::new(TimerId::new(), clock.now(), 100));
+        store.insert(Timer::new(TimerId::new(), clock.now(), 100, None));
 
         clock.advance(100 + TIMER_GRANULARITY_MS);
         assert_eq!(1, store.pop(clock.now()).len());


### PR DESCRIPTION
Replace the hardcoded 2ms sleep in EventHandler::run with a deadline queried from Store. The previous interval was tighter than the wheel's 8ms resolution, so most wakes returned an empty bucket, and the loop kept polling even when no timers were scheduled.

Store::next_deadline returns Some(tick) when overdue timers exist, Some(tick + short_wheel.resolution) when wheels or heap have entries, or None when everything is empty so the loop can sleep on pending until an event arrives.

https://claude.ai/code/session_01Mr1c5QrRYa8hGA4dEdEwgi