### PR TITLE
Add unit tests across wheel, timer, router, handlers, and logger

### DIFF
--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -368,7 +368,7 @@ mod tests {
     fn remove_already_removed_id_returns_false() {
         let (clock, mut store) = setup();
         let id = TimerId::new();
-        store.insert(Timer::new(id.clone(), clock.now(), 100));
+        store.insert(Timer::new(id.clone(), clock.now(), 100, None));
 
         assert!(store.remove(&id));
         assert!(!store.remove(&id));

--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -305,4 +305,20 @@ mod tests {
             panic!("Expected there to be a popped timer.");
         }
     }
+
+    #[test]
+    fn remove_unknown_id_returns_false() {
+        let (_clock, mut store) = setup();
+        assert!(!store.remove(&TimerId::new()));
+    }
+
+    #[test]
+    fn remove_already_removed_id_returns_false() {
+        let (clock, mut store) = setup();
+        let id = TimerId::new();
+        store.insert(Timer::new(id.clone(), clock.now(), 100));
+
+        assert!(store.remove(&id));
+        assert!(!store.remove(&id));
+    }
 }

--- a/src/core/timer.rs
+++ b/src/core/timer.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn pop_time_is_start_plus_interval() {
-        let timer = Timer::new(TimerId::new(), 100, 250);
+        let timer = Timer::new(TimerId::new(), 100, 250, None);
         assert_eq!(timer.pop_time(), 350);
     }
 
@@ -105,8 +105,8 @@ mod tests {
 
     #[test]
     fn ord_reverses_pop_time_for_min_heap() {
-        let earlier = Timer::new(TimerId::new(), 0, 100);
-        let later = Timer::new(TimerId::new(), 0, 200);
+        let earlier = Timer::new(TimerId::new(), 0, 100, None);
+        let later = Timer::new(TimerId::new(), 0, 200, None);
 
         // The smaller pop_time should compare as Greater so a max-heap (BinaryHeap)
         // pops it first — i.e. the heap behaves as a min-heap on pop_time.

--- a/src/core/timer.rs
+++ b/src/core/timer.rs
@@ -57,4 +57,54 @@ impl PartialOrd for Timer {
     }
 }
 
-// Test comparison in min-heap
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn pop_time_is_start_plus_interval() {
+        let timer = Timer::new(TimerId::new(), 100, 250);
+        assert_eq!(timer.pop_time(), 350);
+    }
+
+    #[test]
+    fn timer_id_new_returns_distinct_ids() {
+        let a = TimerId::new();
+        let b = TimerId::new();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn timer_id_default_returns_distinct_ids() {
+        let a = TimerId::default();
+        let b = TimerId::default();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn timer_id_uuid_returns_inner() {
+        let id = TimerId::new();
+        assert_eq!(id.uuid(), id.0);
+    }
+
+    #[test]
+    fn timer_id_round_trips_through_hashset() {
+        let id = TimerId::new();
+        let mut set = HashSet::new();
+        set.insert(id.clone());
+        assert!(set.contains(&id));
+    }
+
+    #[test]
+    fn ord_reverses_pop_time_for_min_heap() {
+        let earlier = Timer::new(TimerId::new(), 0, 100);
+        let later = Timer::new(TimerId::new(), 0, 200);
+
+        // The smaller pop_time should compare as Greater so a max-heap (BinaryHeap)
+        // pops it first — i.e. the heap behaves as a min-heap on pop_time.
+        assert_eq!(earlier.cmp(&later), Ordering::Greater);
+        assert_eq!(later.cmp(&earlier), Ordering::Less);
+        assert_eq!(earlier.partial_cmp(&later), Some(Ordering::Greater));
+    }
+}

--- a/src/core/wheel.rs
+++ b/src/core/wheel.rs
@@ -143,7 +143,7 @@ mod tests {
     use crate::core::timer::TimerId;
 
     fn timer_at(pop_time: TimeT) -> Timer {
-        Timer::new(TimerId::new(), 0, pop_time)
+        Timer::new(TimerId::new(), 0, pop_time, None)
     }
 
     #[test]

--- a/src/core/wheel.rs
+++ b/src/core/wheel.rs
@@ -62,14 +62,6 @@ impl Wheel {
         // TODO handle error if index is outside bounds
     }
 
-    pub fn _get(&self, timer: &Timer) -> Option<&Timer> {
-        let index = self.bucket_index(timer.pop_time());
-        self.buckets
-            .get(index)
-            .expect("Expected bucket at index")
-            .get(timer)
-    }
-
     pub fn remove(&mut self, timer: &Timer) -> bool {
         let index = self.bucket_index(timer.pop_time());
         self.buckets
@@ -136,5 +128,139 @@ impl TimerHeap {
                 break;
             }
         }
+    }
+}
+
+impl Default for TimerHeap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::timer::TimerId;
+
+    fn timer_at(pop_time: TimeT) -> Timer {
+        Timer::new(TimerId::new(), 0, pop_time)
+    }
+
+    #[test]
+    fn short_wheel_constants() {
+        let wheel = Wheel::new_short_wheel();
+        assert_eq!(wheel.resolution, SHORT_WHEEL_RESOLUTION_MS);
+        assert_eq!(wheel.period, SHORT_WHEEL_PERIOD_MS);
+        assert_eq!(wheel.buckets.len(), SHORT_WHEEL_NUM_BUCKETS);
+    }
+
+    #[test]
+    fn long_wheel_constants() {
+        let wheel = Wheel::new_long_wheel();
+        assert_eq!(wheel.resolution, LONG_WHEEL_RESOLUTION_MS);
+        assert_eq!(wheel.period, LONG_WHEEL_PERIOD_MS);
+        assert_eq!(wheel.buckets.len(), LONG_WHEEL_NUM_BUCKETS);
+    }
+
+    #[test]
+    fn bucket_index_wraps_modulo_buckets() {
+        let wheel = Wheel::new_short_wheel();
+        let buckets = SHORT_WHEEL_NUM_BUCKETS as TimeT;
+        let res = SHORT_WHEEL_RESOLUTION_MS;
+
+        assert_eq!(wheel.bucket_index(0), 0);
+        assert_eq!(wheel.bucket_index(res), 1);
+        assert_eq!(wheel.bucket_index(res * buckets), 0);
+        assert_eq!(wheel.bucket_index(res * (buckets + 3)), 3);
+    }
+
+    #[test]
+    fn round_timestamp_rounds_down_to_resolution() {
+        let wheel = Wheel::new_short_wheel();
+        let res = SHORT_WHEEL_RESOLUTION_MS;
+
+        assert_eq!(wheel.round_timestamp(0), 0);
+        assert_eq!(wheel.round_timestamp(res - 1), 0);
+        assert_eq!(wheel.round_timestamp(res), res);
+        assert_eq!(wheel.round_timestamp(res + 1), res);
+        assert_eq!(wheel.round_timestamp(2 * res + 5), 2 * res);
+    }
+
+    #[test]
+    fn should_insert_within_period() {
+        let wheel = Wheel::new_short_wheel();
+        let tick: TimeT = 0;
+
+        // Just inside the period.
+        assert!(wheel.should_insert(&tick, &timer_at(wheel.period - 1)));
+        // Just outside the period (rounded equality fails the strict <).
+        assert!(!wheel.should_insert(&tick, &timer_at(wheel.period)));
+        assert!(!wheel.should_insert(&tick, &timer_at(wheel.period + wheel.resolution)));
+    }
+
+    #[test]
+    fn insert_then_pop_returns_timer() {
+        let mut wheel = Wheel::new_short_wheel();
+        let timer = timer_at(wheel.resolution);
+
+        wheel.insert(timer.clone());
+        let popped = wheel.pop(wheel.resolution);
+
+        assert_eq!(popped.len(), 1);
+        assert!(popped.contains(&timer));
+    }
+
+    #[test]
+    fn pop_empty_bucket_returns_empty() {
+        let mut wheel = Wheel::new_short_wheel();
+        let popped = wheel.pop(0);
+        assert!(popped.is_empty());
+    }
+
+    #[test]
+    fn remove_returns_true_then_false() {
+        let mut wheel = Wheel::new_short_wheel();
+        let timer = timer_at(wheel.resolution);
+
+        wheel.insert(timer.clone());
+        assert!(wheel.remove(&timer));
+        assert!(!wheel.remove(&timer));
+    }
+
+    #[test]
+    fn timer_heap_pops_in_min_pop_time_order() {
+        let mut heap = TimerHeap::new();
+        heap.push(timer_at(300));
+        heap.push(timer_at(100));
+        heap.push(timer_at(200));
+
+        assert_eq!(heap.pop().unwrap().pop_time(), 100);
+        assert_eq!(heap.pop().unwrap().pop_time(), 200);
+        assert_eq!(heap.pop().unwrap().pop_time(), 300);
+        assert!(heap.pop().is_none());
+    }
+
+    #[test]
+    fn timer_heap_remove_buries_tombstoned_timer() {
+        let mut heap = TimerHeap::new();
+        let early = timer_at(100);
+        let later = timer_at(200);
+        heap.push(early.clone());
+        heap.push(later.clone());
+
+        assert!(heap.remove(&early));
+        // Re-tombstoning the same timer is a no-op (HashSet::insert returns false).
+        assert!(!heap.remove(&early));
+
+        assert!(heap.peek().is_some_and(|t| *t == later));
+        assert!(heap.pop().is_some_and(|t| t == later));
+        assert!(heap.pop().is_none());
+    }
+
+    #[test]
+    fn timer_heap_default_matches_new() {
+        let mut heap = TimerHeap::default();
+        assert!(heap.peek().is_none());
+        assert!(heap.pop().is_none());
     }
 }

--- a/src/infra/handlers.rs
+++ b/src/infra/handlers.rs
@@ -59,3 +59,88 @@ impl RouteHandler for TimerHandler {
         Ok(Response::new(full(format!("id: {}", id.0))))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use http::Method;
+    use http_body_util::BodyExt;
+    use hyper::body::Bytes as HyperBytes;
+    use tokio::sync::mpsc;
+
+    fn request(method: Method, body: &[u8]) -> HttpRequest {
+        HttpRequest {
+            method,
+            path: "/timer".to_string(),
+            body: HyperBytes::copy_from_slice(body),
+        }
+    }
+
+    async fn body_bytes(resp: HttpResponse) -> Bytes {
+        resp.into_body().collect().await.unwrap().to_bytes()
+    }
+
+    #[tokio::test]
+    async fn status_handler_returns_ok() {
+        let handler = StatusHandler;
+        let req = HttpRequest {
+            method: Method::GET,
+            path: "/".to_string(),
+            body: HyperBytes::new(),
+        };
+
+        let resp = handler.handle(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_bytes(resp).await, Bytes::from("OK"));
+    }
+
+    #[tokio::test]
+    async fn timer_handler_invalid_json_returns_bad_request() {
+        let (sender, _receiver) = mpsc::channel::<TimerEvent>(1);
+        let handler = TimerHandler::new(sender);
+
+        let resp = handler
+            .handle(request(Method::POST, b"not json"))
+            .await
+            .unwrap_err();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(body_bytes(resp).await, Bytes::from("Invalid JSON"));
+    }
+
+    #[tokio::test]
+    async fn timer_handler_dropped_receiver_returns_service_unavailable() {
+        let (sender, receiver) = mpsc::channel::<TimerEvent>(1);
+        drop(receiver);
+        let handler = TimerHandler::new(sender);
+
+        let resp = handler
+            .handle(request(Method::POST, br#"{"interval_ms": 100}"#))
+            .await
+            .unwrap_err();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body_bytes(resp).await, Bytes::from("Server overloaded"));
+    }
+
+    #[tokio::test]
+    async fn timer_handler_happy_path_sends_event_and_returns_id() {
+        let (sender, mut receiver) = mpsc::channel::<TimerEvent>(1);
+        let handler = TimerHandler::new(sender);
+
+        let resp = handler
+            .handle(request(Method::POST, br#"{"interval_ms": 100}"#))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = receiver.recv().await.unwrap();
+        let TimerEvent::Insert(timer) = event;
+
+        let body = body_bytes(resp).await;
+        let expected = format!("id: {}", timer.id.0);
+        assert_eq!(body, Bytes::from(expected));
+    }
+}

--- a/src/infra/handlers.rs
+++ b/src/infra/handlers.rs
@@ -68,6 +68,8 @@ impl RouteHandler for TimerHandler {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::SystemClock;
+
     use super::*;
     use bytes::Bytes;
     use http::Method;
@@ -103,8 +105,9 @@ mod tests {
 
     #[tokio::test]
     async fn timer_handler_invalid_json_returns_bad_request() {
+        let clock = Arc::new(SystemClock);
         let (sender, _receiver) = mpsc::channel::<TimerEvent>(1);
-        let handler = TimerHandler::new(sender);
+        let handler = TimerHandler::new(sender, clock);
 
         let resp = handler
             .handle(request(Method::POST, b"not json"))
@@ -117,9 +120,10 @@ mod tests {
 
     #[tokio::test]
     async fn timer_handler_dropped_receiver_returns_service_unavailable() {
+        let clock = Arc::new(SystemClock);
         let (sender, receiver) = mpsc::channel::<TimerEvent>(1);
         drop(receiver);
-        let handler = TimerHandler::new(sender);
+        let handler = TimerHandler::new(sender, clock);
 
         let resp = handler
             .handle(request(Method::POST, br#"{"interval_ms": 100}"#))
@@ -132,8 +136,9 @@ mod tests {
 
     #[tokio::test]
     async fn timer_handler_happy_path_sends_event_and_returns_id() {
+        let clock = Arc::new(SystemClock);
         let (sender, mut receiver) = mpsc::channel::<TimerEvent>(1);
-        let handler = TimerHandler::new(sender);
+        let handler = TimerHandler::new(sender, clock);
 
         let resp = handler
             .handle(request(Method::POST, br#"{"interval_ms": 100}"#))

--- a/src/utils/http/router.rs
+++ b/src/utils/http/router.rs
@@ -72,3 +72,86 @@ impl Default for Router {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::http::full;
+    use bytes::Bytes;
+    use http_body_util::BodyExt;
+    use hyper::body::Bytes as HyperBytes;
+
+    struct OkHandler;
+
+    #[async_trait]
+    impl RouteHandler for OkHandler {
+        async fn handle(&self, _req: HttpRequest) -> Result<HttpResponse, HttpResponse> {
+            Ok(Response::new(full("ok")))
+        }
+    }
+
+    struct ErrHandler;
+
+    #[async_trait]
+    impl RouteHandler for ErrHandler {
+        async fn handle(&self, _req: HttpRequest) -> Result<HttpResponse, HttpResponse> {
+            let mut resp = Response::new(full("nope"));
+            *resp.status_mut() = StatusCode::IM_A_TEAPOT;
+            Err(resp)
+        }
+    }
+
+    fn request(method: Method, path: &str) -> HttpRequest {
+        HttpRequest {
+            method,
+            path: path.to_string(),
+            body: HyperBytes::new(),
+        }
+    }
+
+    async fn body_bytes(resp: HttpResponse) -> Bytes {
+        resp.into_body().collect().await.unwrap().to_bytes()
+    }
+
+    #[tokio::test]
+    async fn unknown_route_returns_404() {
+        let router = Router::new();
+        let resp = router.route(request(Method::GET, "/missing")).await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(body_bytes(resp).await, Bytes::from("Not found"));
+    }
+
+    #[tokio::test]
+    async fn default_router_matches_new() {
+        let router = Router::default();
+        let resp = router.route(request(Method::GET, "/")).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn method_mismatch_returns_404() {
+        let router = Router::new().add(Method::GET, "/x", OkHandler);
+
+        let resp = router.route(request(Method::POST, "/x")).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn matching_route_invokes_handler_ok() {
+        let router = Router::new().add(Method::GET, "/x", OkHandler);
+
+        let resp = router.route(request(Method::GET, "/x")).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_bytes(resp).await, Bytes::from("ok"));
+    }
+
+    #[tokio::test]
+    async fn handler_err_response_is_returned() {
+        let router = Router::new().add(Method::GET, "/x", ErrHandler);
+
+        let resp = router.route(request(Method::GET, "/x")).await;
+        assert_eq!(resp.status(), StatusCode::IM_A_TEAPOT);
+        assert_eq!(body_bytes(resp).await, Bytes::from("nope"));
+    }
+}

--- a/src/utils/http/server.rs
+++ b/src/utils/http/server.rs
@@ -173,6 +173,8 @@ mod tests {
         port: u16,
         client: reqwest::Client,
         request_receiver: mpsc::Receiver<HttpRequest>,
+        // Held only so the server keeps running for the duration of the test.
+        #[allow(dead_code)]
         shutdown_sender: oneshot::Sender<()>,
     }
 
@@ -320,29 +322,11 @@ mod tests {
         Ok(())
     }
 
-    #[ignore = "needs fixing"]
-    #[tokio::test]
-    async fn overloaded_server_returns_service_unavailable() -> Result<()> {
-        let TestServerHarness {
-            port,
-            client,
-            request_receiver,
-            shutdown_sender: _shutdown_sender,
-        } = TestServerHarness::new().await;
-
-        // Drop the request receiver to simulate downstream failure
-        drop(request_receiver);
-
-        let resp = client
-            .post(format!("http://127.0.0.1:{}/test", port))
-            .body("hello")
-            .send()
-            .await?;
-
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-
-        Ok(())
-    }
+    // The "overloaded server returns SERVICE_UNAVAILABLE" path lives in
+    // `TimerHandler` (see `infra::handlers::tests::
+    // timer_handler_dropped_receiver_returns_service_unavailable`), not in any
+    // handler used by this server's `TestHandler`, so the previous integration
+    // test here was structurally unable to pass.
 
     #[tokio::test(start_paused = true)]
     async fn slowloris_request_rejected() -> Result<()> {

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -133,6 +133,23 @@ mod tests {
         );
     }
 
-    // TODO timeout
-    // TODO channel close
+    #[tokio::test(start_paused = true)]
+    async fn contains_times_out_when_no_message_arrives() {
+        let logger = StdoutLogger::new().with_receiver();
+        assert!(!logger.contains("never").await);
+    }
+
+    #[tokio::test]
+    async fn contains_returns_false_when_sender_dropped() {
+        let mut logger = StdoutLogger::new().with_receiver();
+        // Drop the only outstanding sender so the receiver yields `Ok(None)`.
+        logger.sender = None;
+        assert!(!logger.contains("anything").await);
+    }
+
+    #[tokio::test]
+    async fn contains_returns_false_without_receiver() {
+        let logger = StdoutLogger::new();
+        assert!(!logger.contains("anything").await);
+    }
 }


### PR DESCRIPTION
Adds 31 tests targeting modules that were previously covered only
indirectly (or not at all) and removes the unused Wheel::_get method:

- core/wheel.rs: bucket math, round_timestamp, should_insert
  boundaries, insert/pop/remove round-trips, TimerHeap ordering and
  tombstone bury behaviour
- core/timer.rs: pop_time arithmetic, TimerId uniqueness/Default/
  uuid(), HashSet round-trip, Ord/PartialOrd reversal for min-heap use
- core/store.rs: remove() of unknown and already-removed ids
- utils/http/router.rs: 404 path, method-mismatch, handler Ok/Err arms
- infra/handlers.rs: StatusHandler OK, TimerHandler invalid-JSON,
  dropped-receiver, and happy-path
- utils/logger.rs: contains() timeout, closed-sender, and
  no-receiver paths

The flaky #[ignore]d overloaded_server_returns_service_unavailable
integration test in server.rs is removed; its intent is covered more
reliably by the new TimerHandler unit test.