### PR TITLE
Add integration tests with deterministic time control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,8 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 bytes = "1.11.1"
 http = "1.4.0"
 serde_json = "1.0.149"
-reqwest = "0.13.3"
+reqwest = { version = "0.13.3", features = ["json"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }

--- a/src/core/clock.rs
+++ b/src/core/clock.rs
@@ -1,0 +1,14 @@
+use crate::core::timer::TimeT;
+use chrono::Utc;
+
+pub trait Clock: Send + Sync {
+    fn now(&self) -> TimeT;
+}
+
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> TimeT {
+        Utc::now().timestamp_millis() as TimeT
+    }
+}

--- a/src/core/event_handler.rs
+++ b/src/core/event_handler.rs
@@ -1,9 +1,8 @@
 use crate::{
-    core::{store::Store, timer::Timer},
+    core::{clock::Clock, store::Store, timer::Timer},
     utils::Logger,
 };
 use anyhow::Result;
-use chrono::Utc;
 use std::sync::Arc;
 use tokio::{
     sync::mpsc::{self, Sender},
@@ -19,12 +18,22 @@ pub struct EventHandler {
 }
 
 impl EventHandler {
-    pub fn new(timer_sender: Sender<Timer>, logger: Arc<dyn Logger>) -> Self {
-        let now = Utc::now().timestamp_millis() as u64;
+    pub fn new(
+        timer_sender: Sender<Timer>,
+        logger: Arc<dyn Logger>,
+        clock: Arc<dyn Clock>,
+    ) -> Self {
+        let now = clock.now();
         let store = Store::new(now);
         let (event_sender, event_receiver) = mpsc::channel::<TimerEvent>(1024);
 
-        tokio::spawn(Self::run(store, event_receiver, timer_sender, logger));
+        tokio::spawn(Self::run(
+            store,
+            event_receiver,
+            timer_sender,
+            logger,
+            clock,
+        ));
 
         Self { event_sender }
     }
@@ -34,6 +43,7 @@ impl EventHandler {
         mut event_receiver: mpsc::Receiver<TimerEvent>,
         timer_sender: mpsc::Sender<Timer>,
         logger: Arc<dyn Logger>,
+        clock: Arc<dyn Clock>,
     ) {
         loop {
             // TODO get deadline from store
@@ -55,7 +65,7 @@ impl EventHandler {
                         futures::future::pending::<()>().await;
                     }
                 } => {
-                    let now = Utc::now().timestamp_millis() as u64;
+                    let now = clock.now();
                     let bucket = store.pop(now);
                     for timer in bucket {
                         let _ = timer_sender.send(timer).await;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,9 @@ mod store;
 mod timer;
 pub use timer::{TimeT, Timer, TimerId};
 
+pub mod clock;
+pub use clock::{Clock, SystemClock};
+
 mod event_handler;
 pub use event_handler::{EventHandler, TimerEvent};
 

--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -175,7 +175,7 @@ mod tests {
     #[test_case(3600 * 1000 * 10; "really_long")]
     fn timer_pops_after_interval(interval: TimeT) {
         let (mut clock, mut store) = setup();
-        store.insert(Timer::new(TimerId::new(), clock.now(), interval));
+        store.insert(Timer::new(TimerId::new(), clock.now(), interval, None));
 
         clock.advance(interval - TIMER_GRANULARITY_MS);
         assert_eq!(0, store.pop(clock.now()).len());
@@ -189,8 +189,8 @@ mod tests {
     #[test_case(3600 * 1000 * 10; "really_long")]
     fn multiple_timers_pop(interval: TimeT) {
         let (mut clock, mut store) = setup();
-        store.insert(Timer::new(TimerId::new(), clock.now(), interval));
-        store.insert(Timer::new(TimerId::new(), clock.now(), interval));
+        store.insert(Timer::new(TimerId::new(), clock.now(), interval, None));
+        store.insert(Timer::new(TimerId::new(), clock.now(), interval, None));
 
         clock.advance(interval - TIMER_GRANULARITY_MS);
         assert_eq!(0, store.pop(clock.now()).len());
@@ -205,7 +205,7 @@ mod tests {
     fn timer_removal_after_interval(interval: TimeT) {
         let (mut clock, mut store) = setup();
         let id = TimerId::new();
-        store.insert(Timer::new(id.clone(), clock.now(), interval));
+        store.insert(Timer::new(id.clone(), clock.now(), interval, None));
 
         store.remove(&id);
 
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(0, store.pop(clock.now()).len());
 
         // Insert a timer set to pop in the past.
-        store.insert(Timer::new(TimerId::new(), 0, 100));
+        store.insert(Timer::new(TimerId::new(), 0, 100, None));
         assert_eq!(1, store.pop(clock.now()).len());
     }
 
@@ -234,7 +234,7 @@ mod tests {
 
         // Insert a timer set to pop in the past.
         let id = TimerId::new();
-        store.insert(Timer::new(id.clone(), 0, 100));
+        store.insert(Timer::new(id.clone(), 0, 100, None));
 
         store.remove(&id);
         assert_eq!(0, store.pop(clock.now()).len());
@@ -250,6 +250,7 @@ mod tests {
             TimerId::new(),
             clock.now(),
             (60 * 60 * 1000) + 1000 + 500,
+            None,
         ));
 
         // Advance by 1h, no timers have popped.
@@ -257,14 +258,14 @@ mod tests {
         assert_eq!(0, store.pop(clock.now()).len());
 
         // Timer 2 pops in 1s + 500ms.
-        store.insert(Timer::new(TimerId::new(), clock.now(), 1000 + 500));
+        store.insert(Timer::new(TimerId::new(), clock.now(), 1000 + 500, None));
 
         // Advance by 1s, no timers have popped.
         clock.advance(1000);
         assert_eq!(0, store.pop(clock.now()).len());
 
         // Timer 3 pops in 500ms.
-        store.insert(Timer::new(TimerId::new(), clock.now(), 500));
+        store.insert(Timer::new(TimerId::new(), clock.now(), 500, None));
 
         // Advance by 500ms + one tick, all timers pop.
         clock.advance(500 + TIMER_GRANULARITY_MS);
@@ -287,12 +288,19 @@ mod tests {
             id_1,
             clock.now(),
             3600 * 1000 * 10 + TIMER_GRANULARITY_MS * 2,
+            None,
         ));
-        store.insert(Timer::new(id_2.clone(), clock.now(), timer_2_interval));
+        store.insert(Timer::new(
+            id_2.clone(),
+            clock.now(),
+            timer_2_interval,
+            None,
+        ));
         store.insert(Timer::new(
             id_3,
             clock.now(),
             3600 * 1000 * 5 + TIMER_GRANULARITY_MS * 6,
+            None,
         ));
 
         clock.advance(timer_2_interval + TIMER_GRANULARITY_MS);

--- a/src/core/timer.rs
+++ b/src/core/timer.rs
@@ -28,14 +28,21 @@ pub struct Timer {
     pub id: TimerId,
     start_time: TimeT,
     interval: TimeT,
+    pub callback_url: Option<String>,
 }
 
 impl Timer {
-    pub fn new(id: TimerId, start_time: TimeT, interval: TimeT) -> Self {
+    pub fn new(
+        id: TimerId,
+        start_time: TimeT,
+        interval: TimeT,
+        callback_url: Option<String>,
+    ) -> Self {
         Self {
             id,
             start_time,
             interval,
+            callback_url,
         }
     }
 

--- a/src/infra/app.rs
+++ b/src/infra/app.rs
@@ -1,11 +1,11 @@
 use crate::{
-    core::{EventHandler, Timer},
+    core::{Clock, EventHandler, Timer},
     infra::event_receiver::EventReceiver,
     utils::Logger,
 };
 use anyhow::{Context, Result};
 use futures::StreamExt;
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 use tokio::sync::{
     mpsc::{self, Receiver},
     oneshot,
@@ -16,22 +16,29 @@ pub struct App {
     event_receiver: EventReceiver,
     timer_receiver: Receiver<Timer>,
     logger: Arc<dyn Logger>,
+    http_client: reqwest::Client,
 }
 
 impl App {
-    pub async fn new(logger: Arc<dyn Logger>) -> Result<Self> {
-        let event_receiver = EventReceiver::new(logger.clone()).await?;
+    pub async fn new(
+        logger: Arc<dyn Logger>,
+        clock: Arc<dyn Clock>,
+        port: u16,
+        shutdown_signal: impl Future<Output = ()> + Send + 'static,
+    ) -> Result<Self> {
+        let event_receiver =
+            EventReceiver::new(logger.clone(), clock.clone(), port, shutdown_signal).await?;
 
-        // Setup publisher
         let (timer_sender, timer_receiver) = mpsc::channel::<Timer>(1024);
 
-        let event_handler = EventHandler::new(timer_sender, logger.clone());
+        let event_handler = EventHandler::new(timer_sender, logger.clone(), clock);
 
         Ok(Self {
             event_handler,
             event_receiver,
             timer_receiver,
             logger,
+            http_client: reqwest::Client::new(),
         })
     }
 
@@ -67,8 +74,21 @@ impl App {
                 }
 
                 // Expired timer
-                Some (_timer) = self.timer_receiver.recv() => {
+                Some(timer) = self.timer_receiver.recv() => {
                     self.logger.info("Timer expired, send to client");
+                    if let Some(ref url) = timer.callback_url {
+                        let url = url.clone();
+                        let logger = self.logger.clone();
+                        let client = self.http_client.clone();
+                        let timer_id = timer.id.uuid().to_string();
+                        tokio::spawn(async move {
+                            let payload = serde_json::json!({ "timer_id": timer_id });
+                            match client.post(&url).json(&payload).send().await {
+                                Ok(_) => logger.info(&format!("Callback sent to {}", url)),
+                                Err(e) => logger.error(&format!("Callback failed to {}: {}", url, e)),
+                            }
+                        });
+                    }
                 }
             }
         }

--- a/src/infra/event_receiver.rs
+++ b/src/infra/event_receiver.rs
@@ -1,12 +1,12 @@
 use crate::{
-    core::TimerEvent,
+    core::{Clock, TimerEvent},
     infra::handlers::{StatusHandler, TimerHandler},
     utils::{Logger, Router, run_server},
 };
 use anyhow::Result;
 use futures::{Stream, StreamExt};
 use hyper::Method;
-use std::{pin::Pin, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::sync::{
     mpsc::{self},
     oneshot,
@@ -21,14 +21,19 @@ pub struct EventReceiver {
 }
 
 impl EventReceiver {
-    pub async fn new(logger: Arc<dyn Logger>) -> Result<Self> {
+    pub async fn new(
+        logger: Arc<dyn Logger>,
+        clock: Arc<dyn Clock>,
+        port: u16,
+        shutdown_signal: impl Future<Output = ()> + Send + 'static,
+    ) -> Result<Self> {
         let (event_sender, event_receiver) = mpsc::channel::<TimerEvent>(1024);
 
         // Build router
         let router = Arc::new(Router::new().add(Method::GET, "/", StatusHandler {}).add(
             Method::POST,
             "/timer",
-            TimerHandler::new(event_sender.clone()),
+            TimerHandler::new(event_sender.clone(), clock),
         ));
 
         // Spawn server
@@ -36,9 +41,9 @@ impl EventReceiver {
         tokio::spawn(run_server(
             router,
             logger.clone(),
-            3000,
+            port,
             ready_sender,
-            shutdown_signal(),
+            shutdown_signal,
         ));
 
         // Wait for the server to be ready
@@ -60,11 +65,4 @@ impl EventReceiver {
             let _ = termination.await;
         })))
     }
-}
-
-async fn shutdown_signal() {
-    // Wait for the CTRL+C signal
-    tokio::signal::ctrl_c()
-        .await
-        .expect("failed to install CTRL+C signal handler");
 }

--- a/src/infra/handlers.rs
+++ b/src/infra/handlers.rs
@@ -1,11 +1,11 @@
 use crate::{
-    core::{TimeT, Timer, TimerEvent, TimerId},
+    core::{Clock, Timer, TimerEvent, TimerId},
     utils::{HttpRequest, HttpResponse, RouteHandler, full},
 };
 use async_trait::async_trait;
-use chrono::Utc;
 use http::{Response, StatusCode};
 use serde::Deserialize;
+use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
 pub struct StatusHandler;
@@ -19,17 +19,22 @@ impl RouteHandler for StatusHandler {
 
 pub struct TimerHandler {
     event_sender: Sender<TimerEvent>,
+    clock: Arc<dyn Clock>,
 }
 
 impl TimerHandler {
-    pub fn new(event_sender: Sender<TimerEvent>) -> Self {
-        Self { event_sender }
+    pub fn new(event_sender: Sender<TimerEvent>, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            event_sender,
+            clock,
+        }
     }
 }
 
 #[derive(Deserialize)]
 struct RequestPayload {
     interval_ms: u64,
+    callback_url: Option<String>,
 }
 
 #[async_trait]
@@ -44,8 +49,9 @@ impl RouteHandler for TimerHandler {
         let id = TimerId::new();
         let timer = Timer::new(
             id.to_owned(),
-            Utc::now().timestamp_millis() as TimeT,
+            self.clock.now(),
             payload.interval_ms,
+            payload.callback_url,
         );
 
         let event = TimerEvent::Insert(timer);

--- a/src/infra/main_program.rs
+++ b/src/infra/main_program.rs
@@ -1,4 +1,5 @@
 use crate::{
+    core::SystemClock,
     infra::app::App,
     utils::{Logger, StdoutLogger},
 };
@@ -38,9 +39,14 @@ impl MainProgram {
     ) -> Result<()> {
         let _ = self.log_startup_banner();
 
-        let mut app = App::new(self.logger.clone())
-            .await
-            .context("Failed to create app")?;
+        let clock = Arc::new(SystemClock);
+        let mut app = App::new(self.logger.clone(), clock, 3000, async {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("failed to install CTRL+C signal handler");
+        })
+        .await
+        .context("Failed to create app")?;
 
         app.run(termination_receiver, readiness_sender)
             .await

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -4,4 +4,5 @@ mod handlers;
 mod main_program;
 pub use main_program::MainProgram;
 
-mod app;
+pub mod app;
+pub use app::App;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,109 @@
+use cuckoo::core::{Clock, TimeT};
+use cuckoo::infra::App;
+use cuckoo::utils::{Logger, StdoutLogger};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
+use tokio::sync::oneshot;
+
+pub struct FakeClock {
+    now: AtomicU64,
+}
+
+impl FakeClock {
+    pub fn new(start: TimeT) -> Arc<Self> {
+        Arc::new(Self {
+            now: AtomicU64::new(start),
+        })
+    }
+
+    pub fn advance(&self, millis: TimeT) {
+        self.now.fetch_add(millis, Ordering::SeqCst);
+    }
+}
+
+impl Clock for FakeClock {
+    fn now(&self) -> TimeT {
+        self.now.load(Ordering::SeqCst)
+    }
+}
+
+pub struct TestHarness {
+    pub port: u16,
+    pub clock: Arc<FakeClock>,
+    pub client: reqwest::Client,
+    pub logger: Arc<StdoutLogger>,
+    termination_sender: Option<oneshot::Sender<()>>,
+    shutdown_sender: Option<oneshot::Sender<()>>,
+}
+
+static PORT: AtomicU16 = AtomicU16::new(4000);
+
+impl TestHarness {
+    pub async fn start() -> Self {
+        let port = PORT.fetch_add(1, Ordering::SeqCst);
+
+        let clock = FakeClock::new(1_000_000);
+        let logger = Arc::new(StdoutLogger::new().with_receiver());
+
+        let (termination_sender, termination_receiver) = oneshot::channel();
+        let (readiness_sender, readiness_receiver) = oneshot::channel();
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
+
+        let app_clock = clock.clone() as Arc<dyn Clock>;
+        let app_logger = logger.clone() as Arc<dyn Logger>;
+
+        tokio::spawn(async move {
+            let mut app = App::new(app_logger, app_clock, port, async {
+                let _ = shutdown_receiver.await;
+            })
+            .await
+            .unwrap();
+            app.run(termination_receiver, readiness_sender)
+                .await
+                .unwrap();
+        });
+
+        readiness_receiver.await.unwrap();
+
+        Self {
+            port,
+            clock,
+            client: reqwest::Client::new(),
+            logger,
+            termination_sender: Some(termination_sender),
+            shutdown_sender: Some(shutdown_sender),
+        }
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.port, path)
+    }
+
+    pub async fn create_timer(
+        &self,
+        interval_ms: u64,
+        callback_url: Option<&str>,
+    ) -> reqwest::Response {
+        let mut payload = serde_json::json!({ "interval_ms": interval_ms });
+        if let Some(url) = callback_url {
+            payload["callback_url"] = serde_json::json!(url);
+        }
+        self.client
+            .post(self.url("/timer"))
+            .json(&payload)
+            .send()
+            .await
+            .unwrap()
+    }
+}
+
+impl Drop for TestHarness {
+    fn drop(&mut self) {
+        if let Some(sender) = self.termination_sender.take() {
+            let _ = sender.send(());
+        }
+        if let Some(sender) = self.shutdown_sender.take() {
+            let _ = sender.send(());
+        }
+    }
+}

--- a/tests/timer_integration.rs
+++ b/tests/timer_integration.rs
@@ -1,0 +1,197 @@
+mod common;
+
+use async_trait::async_trait;
+use common::TestHarness;
+use cuckoo::utils::{
+    HttpRequest, HttpResponse, RouteHandler, Router, StdoutLogger, full, run_server,
+};
+use http::Method;
+use hyper::Response;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, Ordering};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Duration, timeout};
+
+struct CallbackRecorder {
+    sender: mpsc::Sender<String>,
+}
+
+#[async_trait]
+impl RouteHandler for CallbackRecorder {
+    async fn handle(&self, req: HttpRequest) -> Result<HttpResponse, HttpResponse> {
+        let body = String::from_utf8_lossy(&req.body).to_string();
+        let _ = self.sender.send(body).await;
+        Ok(Response::new(full("OK")))
+    }
+}
+
+struct CallbackReceiver {
+    pub port: u16,
+    receiver: mpsc::Receiver<String>,
+    _shutdown_sender: oneshot::Sender<()>,
+}
+
+static CALLBACK_PORT: AtomicU16 = AtomicU16::new(5000);
+
+impl CallbackReceiver {
+    async fn start() -> Self {
+        let port = CALLBACK_PORT.fetch_add(1, Ordering::SeqCst);
+        let (sender, receiver) = mpsc::channel::<String>(64);
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let router =
+            Arc::new(Router::new().add(Method::POST, "/callback", CallbackRecorder { sender }));
+
+        tokio::spawn(run_server(
+            router,
+            Arc::new(StdoutLogger::new()),
+            port,
+            ready_tx,
+            async {
+                let _ = shutdown_rx.await;
+            },
+        ));
+
+        ready_rx.await.unwrap();
+
+        Self {
+            port,
+            receiver,
+            _shutdown_sender: shutdown_tx,
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/callback", self.port)
+    }
+
+    async fn recv(&mut self) -> Option<String> {
+        timeout(Duration::from_secs(2), self.receiver.recv())
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
+#[tokio::test]
+async fn health_check() {
+    let harness = TestHarness::start().await;
+    let resp = harness.client.get(harness.url("/")).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "OK");
+}
+
+#[tokio::test]
+async fn create_timer_returns_id() {
+    let harness = TestHarness::start().await;
+    let resp = harness.create_timer(5000, None).await;
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.starts_with("id: "),
+        "expected 'id: <uuid>', got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn invalid_request_rejected() {
+    let harness = TestHarness::start().await;
+    let resp = harness
+        .client
+        .post(harness.url("/timer"))
+        .body("not json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn timer_fires_callback_after_interval() {
+    let mut cb = CallbackReceiver::start().await;
+    let harness = TestHarness::start().await;
+
+    let resp = harness.create_timer(5000, Some(&cb.url())).await;
+    assert_eq!(resp.status(), 200);
+
+    harness.clock.advance(5000 + 16);
+
+    let body = cb.recv().await.expect("expected callback to be received");
+    assert!(
+        body.contains("timer_id"),
+        "callback body should contain timer_id: {body}"
+    );
+}
+
+#[tokio::test]
+async fn timer_does_not_fire_before_interval() {
+    let mut cb = CallbackReceiver::start().await;
+    let harness = TestHarness::start().await;
+
+    harness.create_timer(5000, Some(&cb.url())).await;
+
+    // Advance clock to just before the timer should fire
+    harness.clock.advance(5000 - 16);
+
+    // Short wait — if the timer incorrectly fires, the callback would arrive quickly
+    let result = timeout(Duration::from_millis(50), cb.receiver.recv()).await;
+    assert!(result.is_err(), "timer should not have fired yet");
+
+    // Now advance past the interval
+    harness.clock.advance(32);
+
+    let body = cb
+        .recv()
+        .await
+        .expect("expected callback after advancing past interval");
+    assert!(body.contains("timer_id"));
+}
+
+#[tokio::test]
+async fn multiple_timers_fire_at_different_times() {
+    let mut cb = CallbackReceiver::start().await;
+    let harness = TestHarness::start().await;
+
+    let resp1 = harness.create_timer(100, Some(&cb.url())).await;
+    assert_eq!(resp1.status(), 200);
+
+    let resp2 = harness.create_timer(500, Some(&cb.url())).await;
+    assert_eq!(resp2.status(), 200);
+
+    // Advance past first timer but not second
+    harness.clock.advance(100 + 16);
+
+    let body1 = cb.recv().await.expect("first timer should have fired");
+    assert!(body1.contains("timer_id"));
+
+    // Second timer should not have fired yet
+    let result = timeout(Duration::from_millis(50), cb.receiver.recv()).await;
+    assert!(result.is_err(), "second timer should not have fired yet");
+
+    // Advance past second timer
+    harness.clock.advance(400 + 16);
+
+    let body2 = cb.recv().await.expect("second timer should have fired");
+    assert!(body2.contains("timer_id"));
+}
+
+#[tokio::test]
+async fn timer_without_callback_does_not_send_request() {
+    let mut cb = CallbackReceiver::start().await;
+    let harness = TestHarness::start().await;
+
+    // Create timer without callback
+    harness.create_timer(100, None).await;
+
+    harness.clock.advance(100 + 16);
+
+    // Verify the timer expired via logs but no callback was sent
+    assert!(harness.logger.contains("Timer expired").await);
+
+    let result = timeout(Duration::from_millis(50), cb.receiver.recv()).await;
+    assert!(
+        result.is_err(),
+        "no callback should be sent for timer without callback_url"
+    );
+}


### PR DESCRIPTION
## Summary
- Introduce a `Clock` trait at the boundary layer (`EventHandler`, `TimerHandler`) so integration tests can control time via a `FakeClock` backed by `AtomicU64` — no real-time waits needed. `Store` remains a pure data structure.
- Add optional `callback_url` to timers. When a timer fires, the server POSTs `{ "timer_id": "<uuid>" }` to the callback URL.
- Make `App`, port, and shutdown signal configurable so tests can start the full server stack programmatically.
- Add 7 integration tests: health check, timer creation, invalid request rejection, callback after interval, no-fire before interval, multiple timers at different times, and no callback when URL is omitted.

## Test plan
- [x] `cargo test` — all 22 existing unit tests pass
- [x] `cargo test --test timer_integration` — all 7 integration tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] Manual smoke test: `cargo run`, then `curl -X POST http://localhost:3000/timer -d '{"interval_ms": 5000, "callback_url": "http://localhost:9999/cb"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)