### PR TITLE
Performance benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,83 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,6 +135,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -90,10 +167,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -139,6 +228,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +302,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -184,6 +346,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,8 +449,11 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "clap",
+ "criterion",
  "ctrlc",
  "futures",
+ "hdrhistogram",
  "http",
  "http-body-util",
  "hyper",
@@ -249,6 +499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +534,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -454,6 +720,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,10 +746,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -562,7 +859,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -744,6 +1041,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +1190,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1226,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -918,6 +1267,18 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -959,6 +1320,34 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1104,6 +1493,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,12 +1522,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1366,6 +1804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1836,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1532,6 +1982,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1716,6 +2176,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ reqwest = { version = "0.13.3", features = ["json"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+hdrhistogram = "7"
+clap = { version = "4", features = ["derive"] }
+
+[[bench]]
+name = "store"
+harness = false

--- a/benches/store.rs
+++ b/benches/store.rs
@@ -1,0 +1,162 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use cuckoo::core::{Store, Timer, TimerId};
+
+// A comfortably large start time so short-wheel timer intervals stay in the
+// future (tick rounds down to ~1_000_000 - 7 = 999_992).
+const NOW: u64 = 1_000_000;
+
+fn make_timer(start: u64, interval: u64) -> Timer {
+    Timer::new(TimerId::new(), start, interval, None)
+}
+
+// Intervals that land each timer in a different storage tier.
+//
+// With NOW=1_000_000 and tick=999_992:
+//   overdue     -> pop_time = 1 < tick
+//   short_wheel -> pop_time = NOW + 500 ≈ 1_000_500 (within SHORT_WHEEL_PERIOD_MS = 1024ms of tick)
+//   long_wheel  -> pop_time = NOW + 2_000 (within LONG_WHEEL_PERIOD_MS ≈ 4.2M ms of tick)
+//   heap        -> pop_time = NOW + 4_300_000 (beyond long wheel)
+const TIERS: &[(&str, u64, u64)] = &[
+    ("overdue", 0, 1),
+    ("short_wheel", NOW, 500),
+    ("long_wheel", NOW, 2_000),
+    ("heap", NOW, 4_300_000),
+];
+
+// ── insert ────────────────────────────────────────────────────────────────────
+
+fn bench_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("store_insert");
+
+    let preload_sizes = [0usize, 1_000, 100_000];
+
+    for &(tier, start, interval) in TIERS {
+        for &size in &preload_sizes {
+            group.bench_with_input(
+                BenchmarkId::new(tier, size),
+                &(start, interval, size),
+                |b, &(start, interval, size)| {
+                    b.iter_batched(
+                        || {
+                            let mut store = Store::new(NOW);
+                            for _ in 0..size {
+                                // Preload with timers spread across the target tier.
+                                store.insert(make_timer(start, interval + 8));
+                            }
+                            store
+                        },
+                        |mut store| {
+                            store.insert(make_timer(start, interval));
+                        },
+                        BatchSize::LargeInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+// ── pop ───────────────────────────────────────────────────────────────────────
+
+fn bench_pop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("store_pop");
+
+    let sizes = [100usize, 10_000];
+
+    for &size in &sizes {
+        // All timers in short wheel, all expiring at NOW+600.
+        group.bench_with_input(
+            BenchmarkId::new("short_wheel_expire", size),
+            &size,
+            |b, &size| {
+                b.iter_batched(
+                    || {
+                        let mut store = Store::new(NOW);
+                        for _ in 0..size {
+                            store.insert(make_timer(NOW, 500));
+                        }
+                        store
+                    },
+                    |mut store| store.pop(NOW + 600),
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        // Timers in long wheel cascade into short wheel at pop.
+        group.bench_with_input(
+            BenchmarkId::new("long_wheel_cascade", size),
+            &size,
+            |b, &size| {
+                b.iter_batched(
+                    || {
+                        let mut store = Store::new(NOW);
+                        for _ in 0..size {
+                            store.insert(make_timer(NOW, 2_000));
+                        }
+                        store
+                    },
+                    |mut store| store.pop(NOW + 3_000),
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    // Pop with nothing expiring — overhead of the tick loop itself.
+    group.bench_function("empty_tick", |b| {
+        b.iter_batched(
+            || {
+                let mut store = Store::new(NOW);
+                store.insert(make_timer(NOW, 60_000));
+                store
+            },
+            |mut store| store.pop(NOW + 100),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ── remove ────────────────────────────────────────────────────────────────────
+
+fn bench_remove(c: &mut Criterion) {
+    let mut group = c.benchmark_group("store_remove");
+
+    let sizes = [100usize, 10_000, 100_000];
+
+    for &(tier, start, interval) in TIERS {
+        for &size in &sizes {
+            group.bench_with_input(
+                BenchmarkId::new(tier, size),
+                &(start, interval, size),
+                |b, &(start, interval, size)| {
+                    b.iter_batched(
+                        || {
+                            let mut store = Store::new(NOW);
+                            let mut ids = Vec::with_capacity(size);
+                            for _ in 0..size {
+                                let id = TimerId::new();
+                                store.insert(Timer::new(id.clone(), start, interval, None));
+                                ids.push(id);
+                            }
+                            (store, ids)
+                        },
+                        |(mut store, ids)| {
+                            store.remove(&ids[ids.len() / 2]);
+                        },
+                        BatchSize::LargeInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_insert, bench_pop, bench_remove);
+criterion_main!(benches);

--- a/benches/store.rs
+++ b/benches/store.rs
@@ -1,3 +1,7 @@
+// How to run:
+// # Microbenchmarks (criterion, HTML report in target/criterion/)
+// cargo bench --bench store
+
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use cuckoo::core::{Store, Timer, TimerId};
 

--- a/examples/load_harness.rs
+++ b/examples/load_harness.rs
@@ -1,0 +1,385 @@
+// Load harness for the cuckoo timer service.
+//
+// Usage:
+//   cargo run --release --example load_harness -- [OPTIONS]
+//
+// Important: run with --release. Debug builds will be significantly slower
+// and will give misleading results.
+
+use async_trait::async_trait;
+use clap::Parser;
+use cuckoo::{
+    core::{Clock, SystemClock},
+    infra::App,
+    utils::{HttpRequest, HttpResponse, LogLevel, Logger, RouteHandler, Router, full, run_server},
+};
+use hdrhistogram::Histogram;
+use http::{Method, Response};
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+use tokio::sync::{mpsc, oneshot};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+fn now_us() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+#[derive(Parser, Debug)]
+#[command(about = "Open-loop load harness for the cuckoo timer service")]
+struct Config {
+    /// Target insert rate (requests per second)
+    #[arg(long, default_value_t = 1000)]
+    rate: u64,
+
+    /// Steady-state measurement window (seconds, excluding 5s warmup)
+    #[arg(long, default_value_t = 30)]
+    duration: u64,
+
+    /// Timer interval in milliseconds — how long each timer should sleep before firing
+    #[arg(long, default_value_t = 500)]
+    interval_ms: u64,
+
+    /// Run calibration: drive GET / at 2× rate to verify generator headroom, then exit
+    #[arg(long)]
+    calibrate: bool,
+
+    /// Port to run the timer service on
+    #[arg(long, default_value_t = 6100)]
+    port: u16,
+
+    /// Port for the callback receiver
+    #[arg(long, default_value_t = 6101)]
+    callback_port: u16,
+}
+
+// ── Silent logger (suppresses SUT noise during benchmarking) ─────────────────
+
+struct NoopLogger;
+
+impl Logger for NoopLogger {
+    fn log(&self, _level: LogLevel, _message: &str) {}
+}
+
+// ── Callback receiver ─────────────────────────────────────────────────────────
+
+// Each callback from the SUT is POST /callback with body { timer_id, pop_time_ms }.
+// The handler records (pop_time_ms, received_ms) for jitter computation.
+struct CallbackHandler {
+    sender: mpsc::Sender<(u64, u64)>,
+}
+
+#[async_trait]
+impl RouteHandler for CallbackHandler {
+    async fn handle(&self, req: HttpRequest) -> Result<HttpResponse, HttpResponse> {
+        let received_ms = now_ms();
+        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&req.body)
+            && let Some(pop_time_ms) = v.get("pop_time_ms").and_then(|v| v.as_u64())
+        {
+            let _ = self.sender.try_send((pop_time_ms, received_ms));
+        }
+        Ok(Response::new(full("OK")))
+    }
+}
+
+async fn start_callback_server(
+    port: u16,
+    sender: mpsc::Sender<(u64, u64)>,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) {
+    let router = Arc::new(Router::new().add(Method::POST, "/callback", CallbackHandler { sender }));
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let logger: Arc<dyn Logger> = Arc::new(NoopLogger);
+    tokio::spawn(run_server(router, logger, port, ready_tx, shutdown));
+    ready_rx.await.unwrap();
+}
+
+// ── Calibration mode ──────────────────────────────────────────────────────────
+
+async fn calibrate(client: &reqwest::Client, sut_url: &str, rate: u64) {
+    let target_rate = rate * 2;
+    let duration_secs = 5u64;
+    let tick = Duration::from_nanos(1_000_000_000 / target_rate);
+    let mut interval = tokio::time::interval(tick);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let url = format!("{}/", sut_url);
+    let start = Instant::now();
+    let mut completed = 0u64;
+    let deadline = start + Duration::from_secs(duration_secs);
+
+    while Instant::now() < deadline {
+        interval.tick().await;
+        let c = client.clone();
+        let u = url.clone();
+        tokio::spawn(async move {
+            let _ = c.get(&u).send().await;
+        });
+        completed += 1;
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    let achieved_rps = completed as f64 / elapsed;
+
+    println!(
+        "=== Calibration (target: {} req/s against GET /) ===",
+        target_rate
+    );
+    println!("  Requests dispatched : {completed}");
+    println!("  Elapsed             : {elapsed:.2}s");
+    println!("  Achieved rate       : {achieved_rps:.0} req/s");
+    if achieved_rps >= target_rate as f64 * 0.9 {
+        println!("  Result: PASS — generator can sustain target rate");
+    } else {
+        println!(
+            "  Result: FAIL — generator only achieved {:.0}% of target ({:.0} req/s).",
+            100.0 * achieved_rps / target_rate as f64,
+            achieved_rps
+        );
+        println!(
+            "          Lower --rate or investigate generator bottleneck before trusting results."
+        );
+    }
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+fn print_histogram(name: &str, h: &Histogram<u64>, unit: &str) {
+    if h.is_empty() {
+        println!("  {name}: no samples");
+        return;
+    }
+    println!("  {name} ({unit}):");
+    println!("    min   = {}", h.min());
+    println!("    p50   = {}", h.value_at_quantile(0.50));
+    println!("    p95   = {}", h.value_at_quantile(0.95));
+    println!("    p99   = {}", h.value_at_quantile(0.99));
+    println!("    p99.9 = {}", h.value_at_quantile(0.999));
+    println!("    max   = {}", h.max());
+    println!("    count = {}", h.len());
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    let cfg = Config::parse();
+
+    // Start the SUT.
+    let clock: Arc<dyn Clock> = Arc::new(SystemClock);
+    let logger: Arc<dyn Logger> = Arc::new(NoopLogger);
+    let (term_tx, term_rx) = oneshot::channel::<()>();
+    let (ready_tx, ready_rx) = oneshot::channel::<()>();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let port = cfg.port;
+
+    {
+        let app_clock = clock.clone();
+        let app_logger = logger.clone();
+        tokio::spawn(async move {
+            let mut app = App::new(app_logger, app_clock, port, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("Failed to start App");
+            app.run(term_rx, ready_tx).await.expect("App run failed");
+        });
+    }
+    ready_rx.await.expect("App failed to signal readiness");
+
+    let sut_url = format!("http://127.0.0.1:{}", cfg.port);
+
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(512)
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+
+    if cfg.calibrate {
+        calibrate(&client, &sut_url, cfg.rate).await;
+        let _ = term_tx.send(());
+        let _ = shutdown_tx.send(());
+        return;
+    }
+
+    // Start callback server.
+    let (cb_tx, cb_rx) = mpsc::channel::<(u64, u64)>(65536);
+    let (cb_shutdown_tx, cb_shutdown_rx) = oneshot::channel::<()>();
+    start_callback_server(cfg.callback_port, cb_tx, async {
+        let _ = cb_shutdown_rx.await;
+    })
+    .await;
+
+    let callback_url = format!("http://127.0.0.1:{}/callback", cfg.callback_port);
+
+    // Shared histograms: insert latency in µs, jitter in ms.
+    let insert_hist = Arc::new(Mutex::new(Histogram::<u64>::new(4).unwrap()));
+    let jitter_hist = Arc::new(Mutex::new(Histogram::<u64>::new(4).unwrap()));
+
+    let warmup_secs = 5u64;
+    let total_secs = warmup_secs + cfg.duration;
+    let tick = Duration::from_nanos(1_000_000_000 / cfg.rate.max(1));
+
+    println!("=== Cuckoo Load Harness ===");
+    println!("  Rate:         {} req/s (open-loop)", cfg.rate);
+    println!(
+        "  Duration:     {}s + {}s warmup",
+        cfg.duration, warmup_secs
+    );
+    println!("  Timer interval: {}ms", cfg.interval_ms);
+    println!("  SUT:          {sut_url}");
+    println!("  Callback:     {callback_url}");
+    println!();
+    println!(
+        "Note: first {warmup_secs}s are discarded as warmup. Run with --calibrate first to verify generator headroom."
+    );
+    println!("      Monitor SUT CPU separately: top -pid $(pgrep -f 'load_harness')");
+    println!();
+
+    let run_start = Instant::now();
+    let warmup_end = run_start + Duration::from_secs(warmup_secs);
+    let load_end = run_start + Duration::from_secs(total_secs);
+
+    // Generator task.
+    let insert_hist_gen = insert_hist.clone();
+    let client_gen = client.clone();
+    let sut_url_gen = sut_url.clone();
+    let callback_url_gen = callback_url.clone();
+    let interval_ms = cfg.interval_ms;
+
+    let gen_handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(tick);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        while Instant::now() < load_end {
+            ticker.tick().await;
+            let in_warmup = Instant::now() < warmup_end;
+            let c = client_gen.clone();
+            let url = sut_url_gen.clone();
+            let cb_url = callback_url_gen.clone();
+            let hist = insert_hist_gen.clone();
+
+            tokio::spawn(async move {
+                let payload = serde_json::json!({
+                    "interval_ms": interval_ms,
+                    "callback_url": cb_url,
+                });
+                let t0 = now_us();
+                if let Ok(resp) = c.post(format!("{url}/timer")).json(&payload).send().await
+                    && resp.status().is_success()
+                    && !in_warmup
+                {
+                    let latency_us = now_us().saturating_sub(t0);
+                    if let Ok(mut h) = hist.lock() {
+                        let _ = h.record(latency_us);
+                    }
+                }
+            });
+        }
+    });
+
+    // Stats sampler task.
+    let client_stats = client.clone();
+    let stats_url = format!("{sut_url}/stats");
+    let stats_handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(1));
+        while Instant::now() < load_end {
+            ticker.tick().await;
+            let elapsed = run_start.elapsed().as_secs_f64();
+            let phase = if Instant::now() < warmup_end {
+                "WARMUP"
+            } else {
+                "LOAD  "
+            };
+            match client_stats.get(&stats_url).send().await {
+                Ok(r) if r.status().is_success() => {
+                    if let Ok(body) = r.text().await {
+                        println!("[{elapsed:6.1}s {phase}] {body}");
+                    }
+                }
+                _ => println!("[{elapsed:6.1}s {phase}] /stats unavailable"),
+            }
+        }
+    });
+
+    // Callback consumer task.
+    let jitter_hist_cb = jitter_hist.clone();
+    let mut cb_rx = cb_rx;
+    let cb_handle = tokio::spawn(async move {
+        while Instant::now() < load_end {
+            match tokio::time::timeout(Duration::from_millis(100), cb_rx.recv()).await {
+                Ok(Some((pop_time_ms, received_ms))) => {
+                    let past_warmup = Instant::now() >= warmup_end;
+                    if past_warmup {
+                        let jitter_ms = received_ms.saturating_sub(pop_time_ms);
+                        if let Ok(mut h) = jitter_hist_cb.lock() {
+                            let _ = h.record(jitter_ms);
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => {}
+            }
+        }
+        // Drain remaining callbacks after load_end.
+        tokio::time::sleep(Duration::from_millis(interval_ms + 2000)).await;
+        while let Ok((pop_time_ms, received_ms)) = cb_rx.try_recv() {
+            let jitter_ms = received_ms.saturating_sub(pop_time_ms);
+            if let Ok(mut h) = jitter_hist_cb.lock() {
+                let _ = h.record(jitter_ms);
+            }
+        }
+    });
+
+    gen_handle.await.unwrap();
+    stats_handle.await.unwrap();
+    cb_handle.await.unwrap();
+
+    // Report.
+    println!();
+    println!("=== Results (steady-state, {}s window) ===", cfg.duration);
+    println!();
+
+    {
+        let h = insert_hist.lock().unwrap();
+        print_histogram("Insert latency (POST /timer → 200 OK)", &h, "µs");
+    }
+    println!();
+    {
+        let h = jitter_hist.lock().unwrap();
+        print_histogram(
+            "Firing jitter (callback_received_ms - expected_pop_time_ms)",
+            &h,
+            "ms",
+        );
+    }
+
+    println!();
+    println!("Interpretation:");
+    println!("  - If insert latency p99 > 50ms: HTTP layer or event channel is saturated.");
+    println!(
+        "  - If jitter p99 > 10ms: event-handler poll interval or callback path is the bottleneck."
+    );
+    println!(
+        "  - Check /stats channel_capacity_remaining → 0 means a channel is the first bottleneck."
+    );
+    println!("  - Re-run at higher --rate until a metric degrades to find the saturation point.");
+
+    let _ = term_tx.send(());
+    let _ = shutdown_tx.send(());
+    let _ = cb_shutdown_tx.send(());
+}

--- a/examples/load_harness.rs
+++ b/examples/load_harness.rs
@@ -5,6 +5,16 @@
 //
 // Important: run with --release. Debug builds will be significantly slower
 // and will give misleading results.
+//
+// Examples:
+//   # Calibration — verify generator has headroom before trusting results
+//   cargo run --release --example load_harness -- --calibrate --rate 5000
+//
+//   # Full load test (1000 req/s for 30s steady-state)
+//   cargo run --release --example load_harness -- --rate 1000 --duration 30 --interval-ms 500
+//
+//   # Find saturation point — sweep rates until metrics degrade
+//   cargo run --release --example load_harness -- --rate 5000 --duration 30
 
 use async_trait::async_trait;
 use clap::Parser;

--- a/src/core/event_handler.rs
+++ b/src/core/event_handler.rs
@@ -25,7 +25,6 @@ impl EventHandler {
         timer_sender: Sender<Timer>,
         logger: Arc<dyn Logger>,
         clock: Arc<dyn Clock>,
-        poll_interval: Duration,
         active_count: Arc<AtomicUsize>,
     ) -> Self {
         let now = clock.now();
@@ -38,7 +37,6 @@ impl EventHandler {
             timer_sender,
             logger,
             clock,
-            poll_interval,
             active_count,
         ));
 
@@ -51,7 +49,6 @@ impl EventHandler {
         timer_sender: mpsc::Sender<Timer>,
         logger: Arc<dyn Logger>,
         clock: Arc<dyn Clock>,
-        poll_interval: Duration,
         active_count: Arc<AtomicUsize>,
     ) {
         loop {

--- a/src/core/event_handler.rs
+++ b/src/core/event_handler.rs
@@ -3,7 +3,10 @@ use crate::{
     utils::Logger,
 };
 use anyhow::Result;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use tokio::{
     sync::mpsc::{self, Sender},
     time::{Duration, Instant, sleep_until},
@@ -22,6 +25,8 @@ impl EventHandler {
         timer_sender: Sender<Timer>,
         logger: Arc<dyn Logger>,
         clock: Arc<dyn Clock>,
+        poll_interval: Duration,
+        active_count: Arc<AtomicUsize>,
     ) -> Self {
         let now = clock.now();
         let store = Store::new(now);
@@ -33,6 +38,8 @@ impl EventHandler {
             timer_sender,
             logger,
             clock,
+            poll_interval,
+            active_count,
         ));
 
         Self { event_sender }
@@ -44,17 +51,22 @@ impl EventHandler {
         timer_sender: mpsc::Sender<Timer>,
         logger: Arc<dyn Logger>,
         clock: Arc<dyn Clock>,
+        poll_interval: Duration,
+        active_count: Arc<AtomicUsize>,
     ) {
         loop {
             // TODO get deadline from store
-            let next_deadline = Some(Instant::now() + Duration::from_millis(2));
+            let next_deadline = Some(Instant::now() + poll_interval);
 
             tokio::select! {
                 // New event arrived
                 Some(event) = event_receiver.recv() => {
                     logger.info("new event arrived");
                     match event {
-                        TimerEvent::Insert(timer) => store.insert(timer),
+                        TimerEvent::Insert(timer) => {
+                            store.insert(timer);
+                            active_count.fetch_add(1, Ordering::Relaxed);
+                        }
                     }
                 }
                 // Timer fired
@@ -67,6 +79,7 @@ impl EventHandler {
                 } => {
                     let now = clock.now();
                     let bucket = store.pop(now);
+                    active_count.fetch_sub(bucket.len(), Ordering::Relaxed);
                     for timer in bucket {
                         let _ = timer_sender.send(timer).await;
                     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 mod store;
+pub use store::Store;
 
 mod timer;
 pub use timer::{TimeT, Timer, TimerId};

--- a/src/infra/app.rs
+++ b/src/infra/app.rs
@@ -9,12 +9,9 @@ use std::{
     future::Future,
     sync::{Arc, atomic::AtomicUsize},
 };
-use tokio::{
-    sync::{
-        mpsc::{self, Receiver},
-        oneshot,
-    },
-    time::Duration,
+use tokio::sync::{
+    mpsc::{self, Receiver},
+    oneshot,
 };
 
 pub struct App {
@@ -45,13 +42,7 @@ impl App {
         )
         .await?;
 
-        let event_handler = EventHandler::new(
-            timer_sender,
-            logger.clone(),
-            clock,
-            Duration::from_millis(2),
-            active_count,
-        );
+        let event_handler = EventHandler::new(timer_sender, logger.clone(), clock, active_count);
 
         Ok(Self {
             event_handler,

--- a/src/infra/app.rs
+++ b/src/infra/app.rs
@@ -5,10 +5,16 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use futures::StreamExt;
-use std::{future::Future, sync::Arc};
-use tokio::sync::{
-    mpsc::{self, Receiver},
-    oneshot,
+use std::{
+    future::Future,
+    sync::{Arc, atomic::AtomicUsize},
+};
+use tokio::{
+    sync::{
+        mpsc::{self, Receiver},
+        oneshot,
+    },
+    time::Duration,
 };
 
 pub struct App {
@@ -26,12 +32,26 @@ impl App {
         port: u16,
         shutdown_signal: impl Future<Output = ()> + Send + 'static,
     ) -> Result<Self> {
-        let event_receiver =
-            EventReceiver::new(logger.clone(), clock.clone(), port, shutdown_signal).await?;
-
         let (timer_sender, timer_receiver) = mpsc::channel::<Timer>(1024);
+        let active_count = Arc::new(AtomicUsize::new(0));
 
-        let event_handler = EventHandler::new(timer_sender, logger.clone(), clock);
+        let event_receiver = EventReceiver::new(
+            logger.clone(),
+            clock.clone(),
+            port,
+            shutdown_signal,
+            timer_sender.clone(),
+            active_count.clone(),
+        )
+        .await?;
+
+        let event_handler = EventHandler::new(
+            timer_sender,
+            logger.clone(),
+            clock,
+            Duration::from_millis(2),
+            active_count,
+        );
 
         Ok(Self {
             event_handler,
@@ -81,8 +101,12 @@ impl App {
                         let logger = self.logger.clone();
                         let client = self.http_client.clone();
                         let timer_id = timer.id.uuid().to_string();
+                        let pop_time_ms = timer.pop_time();
                         tokio::spawn(async move {
-                            let payload = serde_json::json!({ "timer_id": timer_id });
+                            let payload = serde_json::json!({
+                                "timer_id": timer_id,
+                                "pop_time_ms": pop_time_ms,
+                            });
                             match client.post(&url).json(&payload).send().await {
                                 Ok(_) => logger.info(&format!("Callback sent to {}", url)),
                                 Err(e) => logger.error(&format!("Callback failed to {}: {}", url, e)),

--- a/src/infra/event_receiver.rs
+++ b/src/infra/event_receiver.rs
@@ -1,14 +1,18 @@
 use crate::{
-    core::{Clock, TimerEvent},
-    infra::handlers::{StatusHandler, TimerHandler},
+    core::{Clock, Timer, TimerEvent},
+    infra::handlers::{StatsHandler, StatusHandler, TimerHandler},
     utils::{Logger, Router, run_server},
 };
 use anyhow::Result;
 use futures::{Stream, StreamExt};
 use hyper::Method;
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, atomic::AtomicUsize},
+};
 use tokio::sync::{
-    mpsc::{self},
+    mpsc::{self, Sender},
     oneshot,
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -26,15 +30,24 @@ impl EventReceiver {
         clock: Arc<dyn Clock>,
         port: u16,
         shutdown_signal: impl Future<Output = ()> + Send + 'static,
+        timer_sender: Sender<Timer>,
+        active_count: Arc<AtomicUsize>,
     ) -> Result<Self> {
         let (event_sender, event_receiver) = mpsc::channel::<TimerEvent>(1024);
 
+        let stats = StatsHandler::new(active_count, event_sender.clone(), timer_sender);
+
         // Build router
-        let router = Arc::new(Router::new().add(Method::GET, "/", StatusHandler {}).add(
-            Method::POST,
-            "/timer",
-            TimerHandler::new(event_sender.clone(), clock),
-        ));
+        let router = Arc::new(
+            Router::new()
+                .add(Method::GET, "/", StatusHandler {})
+                .add(
+                    Method::POST,
+                    "/timer",
+                    TimerHandler::new(event_sender.clone(), clock),
+                )
+                .add(Method::GET, "/stats", stats),
+        );
 
         // Spawn server
         let (ready_sender, ready_receiver) = oneshot::channel();

--- a/src/infra/handlers.rs
+++ b/src/infra/handlers.rs
@@ -5,7 +5,10 @@ use crate::{
 use async_trait::async_trait;
 use http::{Response, StatusCode};
 use serde::Deserialize;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use tokio::sync::mpsc::Sender;
 
 pub struct StatusHandler;
@@ -14,6 +17,38 @@ pub struct StatusHandler;
 impl RouteHandler for StatusHandler {
     async fn handle(&self, _req: HttpRequest) -> Result<HttpResponse, HttpResponse> {
         Ok(Response::new(full("OK")))
+    }
+}
+
+pub struct StatsHandler {
+    active_count: Arc<AtomicUsize>,
+    event_sender: Sender<TimerEvent>,
+    timer_sender: Sender<Timer>,
+}
+
+impl StatsHandler {
+    pub fn new(
+        active_count: Arc<AtomicUsize>,
+        event_sender: Sender<TimerEvent>,
+        timer_sender: Sender<Timer>,
+    ) -> Self {
+        Self {
+            active_count,
+            event_sender,
+            timer_sender,
+        }
+    }
+}
+
+#[async_trait]
+impl RouteHandler for StatsHandler {
+    async fn handle(&self, _req: HttpRequest) -> Result<HttpResponse, HttpResponse> {
+        let body = serde_json::json!({
+            "active_timer_count": self.active_count.load(Ordering::Relaxed),
+            "event_channel_capacity_remaining": self.event_sender.capacity(),
+            "fired_channel_capacity_remaining": self.timer_sender.capacity(),
+        });
+        Ok(Response::new(full(body.to_string())))
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,4 +2,4 @@ mod http;
 pub use http::{HttpRequest, HttpResponse, RouteHandler, Router, full, run_server};
 
 mod logger;
-pub use logger::{Logger, StdoutLogger};
+pub use logger::{LogLevel, Logger, StdoutLogger};


### PR DESCRIPTION
**Production code changes (minimal, all additive):**
- src/core/mod.rs — exports Store publicly so benchmarks can instantiate it directly
- src/core/event_handler.rs — poll_interval: Duration and active_count: Arc<AtomicUsize> are now constructor parameters; the loop increments/decrements the counter on every insert and pop
- src/infra/handlers.rs — new StatsHandler that reports active_timer_count, event_channel_capacity_remaining, and fired_channel_capacity_remaining as JSON
- src/infra/event_receiver.rs — registers GET /stats via the existing router
- src/infra/app.rs — creates timer_sender and active_count before EventReceiver (so both can be shared with the stats handler); callback payload now includes "pop_time_ms" alongside "timer_id"
- src/utils/mod.rs — re-exports LogLevel so external code can implement Logger

**New files:**
- benches/store.rs — criterion microbenchmarks for Store::insert, Store::pop, and Store::remove across all four storage tiers (overdue, short wheel, long wheel, heap) and preload sizes up to 100k timers
- examples/load_harness.rs — open-loop system-level load harness with: calibration mode (--calibrate), insert-latency histogram (µs), firing-jitter histogram (ms from pop_time_ms in callback), live /stats sampling every second, and an interpretation guide in the final report

**How to run:**
```Rust
// Microbenchmarks (criterion, HTML report in target/criterion/)
cargo bench --bench store

// Calibration — verify generator has headroom before trusting results
cargo run --release --example load_harness -- --calibrate --rate 5000

// Full load test (1000 req/s for 30s steady-state)
cargo run --release --example load_harness -- --rate 1000 --duration 30 --interval-ms 500

// Find saturation point — sweep rates until metrics degrade
cargo run --release --example load_harness -- --rate 5000 --duration 30
```