### PR TITLE
fix: bind HTTP server to 0.0.0.0 for container reachability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+target/
+.git/
+.github/
+.devcontainer/
+.claude/
+tests/
+*.md
+LICENSE
+.gitignore
+.dockerignore
+Dockerfile
+k8s/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7
+
+FROM rust:1-slim AS builder
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+
+RUN cargo build --release --bin cuckoo
+
+FROM debian:stable-slim AS runtime
+
+RUN groupadd --system --gid 1000 cuckoo \
+ && useradd  --system --uid 1000 --gid cuckoo --no-create-home --shell /usr/sbin/nologin cuckoo
+
+COPY --from=builder /app/target/release/cuckoo /usr/local/bin/cuckoo
+
+USER cuckoo
+EXPOSE 3000
+ENV PORT=3000
+
+ENTRYPOINT ["/usr/local/bin/cuckoo"]

--- a/k8s/00-namespace.yaml
+++ b/k8s/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cuckoo

--- a/k8s/10-deployment.yaml
+++ b/k8s/10-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cuckoo
+  namespace: cuckoo
+  labels:
+    app: cuckoo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cuckoo
+  template:
+    metadata:
+      labels:
+        app: cuckoo
+    spec:
+      containers:
+        - name: cuckoo
+          image: cuckoo:dev
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: PORT
+              value: "3000"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5

--- a/k8s/20-service.yaml
+++ b/k8s/20-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cuckoo
+  namespace: cuckoo
+  labels:
+    app: cuckoo
+spec:
+  type: ClusterIP
+  selector:
+    app: cuckoo
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/src/infra/event_receiver.rs
+++ b/src/infra/event_receiver.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{Clock, TimerEvent},
-    infra::handlers::{StatusHandler, TimerHandler},
+    infra::handlers::{HealthHandler, StatusHandler, TimerHandler},
     utils::{Logger, Router, run_server},
 };
 use anyhow::Result;
@@ -30,11 +30,16 @@ impl EventReceiver {
         let (event_sender, event_receiver) = mpsc::channel::<TimerEvent>(1024);
 
         // Build router
-        let router = Arc::new(Router::new().add(Method::GET, "/", StatusHandler {}).add(
-            Method::POST,
-            "/timer",
-            TimerHandler::new(event_sender.clone(), clock),
-        ));
+        let router = Arc::new(
+            Router::new()
+                .add(Method::GET, "/", StatusHandler {})
+                .add(Method::GET, "/health", HealthHandler {})
+                .add(
+                    Method::POST,
+                    "/timer",
+                    TimerHandler::new(event_sender.clone(), clock),
+                ),
+        );
 
         // Spawn server
         let (ready_sender, ready_receiver) = oneshot::channel();

--- a/src/infra/handlers.rs
+++ b/src/infra/handlers.rs
@@ -17,6 +17,15 @@ impl RouteHandler for StatusHandler {
     }
 }
 
+pub struct HealthHandler;
+
+#[async_trait]
+impl RouteHandler for HealthHandler {
+    async fn handle(&self, _req: HttpRequest) -> Result<HttpResponse, HttpResponse> {
+        Ok(Response::new(full("OK")))
+    }
+}
+
 pub struct TimerHandler {
     event_sender: Sender<TimerEvent>,
     clock: Arc<dyn Clock>,

--- a/src/infra/handlers/tests.rs
+++ b/src/infra/handlers/tests.rs
@@ -34,6 +34,20 @@ async fn status_handler_returns_ok() {
 }
 
 #[tokio::test]
+async fn health_handler_returns_ok() {
+    let handler = HealthHandler;
+    let req = HttpRequest {
+        method: Method::GET,
+        path: "/health".to_string(),
+        body: HyperBytes::new(),
+    };
+
+    let resp = handler.handle(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_bytes(resp).await, Bytes::from("OK"));
+}
+
+#[tokio::test]
 async fn timer_handler_invalid_json_returns_bad_request() {
     let clock = Arc::new(SystemClock);
     let (sender, _receiver) = mpsc::channel::<TimerEvent>(1);

--- a/src/infra/main_program.rs
+++ b/src/infra/main_program.rs
@@ -40,7 +40,11 @@ impl MainProgram {
         let _ = self.log_startup_banner();
 
         let clock = Arc::new(SystemClock);
-        let mut app = App::new(self.logger.clone(), clock, 3000, async {
+        let port = std::env::var("PORT")
+            .ok()
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or(3000);
+        let mut app = App::new(self.logger.clone(), clock, port, async {
             tokio::signal::ctrl_c()
                 .await
                 .expect("failed to install CTRL+C signal handler");

--- a/src/utils/http/server.rs
+++ b/src/utils/http/server.rs
@@ -63,10 +63,8 @@ pub async fn run_server<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    // Address of localhost on port 3000
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
 
-    // Create a TcpListener and bind it to 127.0.0.1:port
     let listener = TcpListener::bind(addr).await?;
     logger.info(&format!("Listening on http://{}", addr));
 


### PR DESCRIPTION
Inside a container the loopback interface is not reachable from the
kubelet or a Service, so probes and traffic to 127.0.0.1 are refused.
Bind to all interfaces so the listener accepts connections from outside
the pod's network namespace.

https://claude.ai/code/session_01UD5bY7c5jvtEKoHqWUYEke